### PR TITLE
#14 added naming conventions as discussed in FHIR TC Calls

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to hl7-at-fhir-profiles
 
-The following is a set of guidelines for contributing to the hl7-at-fhir-profiles project and its packages, 
-which are hosted in the HL7-Austria Organization on GitHub. These are mostly guidelines, not rules. Use your best judgment, 
+The following is a set of guidelines for contributing to the hl7-at-fhir-profiles project and its packages,
+which are hosted in the HL7-Austria Organization on GitHub. These are mostly guidelines, not rules. Use your best judgment,
 and feel free to propose changes to this document in a pull request.
 
 <!-- TOC -->
@@ -44,7 +44,7 @@ This project and everyone participating in it is governed by HL7 Austria FHIR Te
 - TBD
 
 ### Request New Profiles/Extensions
-In order to request a new Profile or an Extension either create an issue with the label `enhancement` or send an email to [tc-fhir](mailto:tcfhir@hl7.at) 
+In order to request a new Profile or an Extension either create an issue with the label `enhancement` or send an email to [tc-fhir](mailto:tcfhir@hl7.at)
 Use the issue to describe the intented use case and if applicable state some examples.
 
 #### How Do I Submit a (Good) Enhancement
@@ -71,7 +71,71 @@ A commit message must start with the correspoinding ticket number in GitHub (#TI
 
 ### Naming Conventions
 
-- TBD (depends on results from issue #14)
+In general the HL7 [FHIR naming conventions](http://wiki.hl7.org/index.php?title=FHIR_Guide_to_Designing_Resources#Naming_Rules_.26_Guidelines) apply. Essentially these conventions ask for **consistency** and **precision** (i.e. minimizing ambiguity, while ensuring the meaning is easily understood) when naming fields, resources or operations.
+
+Most of these guidelines are suggestions, except the following rules that *must* be followed:
+-  be lowerCamelCase for elements, UpperCamelCase for resources, be lowercase for operations
+-  be U.S. English (spelled correctly!)
+-  be expressed as a noun, with a preceding adjective where necessary to clarify the semantics and to make unique
+-  not make use of trade-marked terms
+
+#### Profile Naming conventions
+
+A profile follows a prefix pattern, meaning that a name from left to right goes from specific to generic. It uses UpperCamelCase.
+
+**ProfileName** = [*Realm*-] *Use* , *ParentProfile*
+**Realm** = Is this profile supposed to be used in a realm? Then use the **countryCode**
+**Use** = What is this profile used for? **UpperCamelCase**
+**ParentProfile** =  Which profile does this profile extend from? **UpperCamelCase**
+
+Example: Patient used in Austria, for ELGA.
+```
+Realm = Austria -> at- (country code)
+Use = ELGA -> Elga
+ParentProfile = Patient -> Patient
+at-ElgaPatient
+```
+
+Example: Patient minimal information for Patient Summary in any Realm
+```
+Realm = any -> no prefix
+Use = Patient Summary -> PatientSummary
+ParentProfile = Patient -> Patient
+PatientSummaryPatient
+```
+
+#### Extension Naming conventions
+
+An extension follows a suffix pattern, meaning that a name from left to right goes from generic to specific. It uses lowerCamelCase.
+
+**ExtensionName** = [*ProfileItIsFor*], {*FieldWithChildrenItIsIn*}, *FieldItAdds*
+**ProfileItIsFor** = Either Base Profile or **Profile** previously defined (optional if extension can occur anywhere -> Ex. NullFlavor), without the Realm.
+**FieldWithChildrenItIsIn** = Optional and Repeating, represents the **hierarchy** where the extension is to be used (optionaly if it can occur anywhere).
+**FieldItAdds** = **unique naming** for field
+
+Example: Extra patient field for "Sozialversicherungsnummer"
+```
+Profile = at-Patient -> patient
+FieldWithChildrenitIsIn = identifier -> Identifier
+FieldItAdds = Sozialversicherungsnummer -> Ssnr (or SocialSecurityNumber)
+patientIdentifierSsnr
+```
+
+Example: Extra field strength in Composition, for Allergies of a PatientSummary
+```
+Profile = PatientSummaryComposition -> patientSummaryComposition
+FieldWithChildrenitIsIn = Section Patient - Section Allergies  -> SectionPatientSubsectionAllergies (here we clarify which section, instead of writing SectionSection)
+FieldItAdds = Strength -> Strength
+patientSummaryCompositionSectionPatientSectionAllergiesStrength
+```
+
+Example: Field nullFlavor that can be added anywhere
+```
+Profile = none -> ""
+FieldWithChildrenitIsIn = any -> ""
+FieldItAdds = nullFlavor -> nullFlavor
+nullFlavor
+```
 
 ## Additional Information
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to hl7-at-fhir-profiles
 
 The following is a set of guidelines for contributing to the hl7-at-fhir-profiles project and its packages,
-which are hosted in the HL7-Austria Organization on GitHub. These are mostly guidelines, not rules. Use your best judgment,
+which are hosted in the HL7-Austria organization on GitHub. These are mostly guidelines, not rules. Use your best judgment,
 and feel free to propose changes to this document in a pull request.
 
 <!-- TOC -->
@@ -15,7 +15,7 @@ and feel free to propose changes to this document in a pull request.
         - [Request New Profiles/Extensions](#request-new-profilesextensions)
             - [How Do I Submit a (Good) Enhancement](#how-do-i-submit-a-good-enhancement)
     - [Issue and Pull Request Labels](#issue-and-pull-request-labels)
-    - [Styleguides](#styleguides)
+    - [Style guides](#styleguides)
         - [Git Commit Messages](#git-commit-messages)
         - [Naming Conventions](#naming-conventions)
     - [Additional Information](#additional-information)
@@ -25,7 +25,7 @@ and feel free to propose changes to this document in a pull request.
 
 ## Code of Conduct
 
-This project and everyone participating in it is governed by HL7 Austria FHIR Technical Comitee. By participating, you are expected to uphold this code. Please report unacceptable behavior to tcfhir@hl7.at.
+This project and everyone participating in it is governed by HL7 Austria FHIR Technical Committee. By participating, you are expected to uphold this code. Please report unacceptable behavior to tcfhir@hl7.at.
 
 ## How Can I Contribute?
 
@@ -44,8 +44,8 @@ This project and everyone participating in it is governed by HL7 Austria FHIR Te
 - TBD
 
 ### Request New Profiles/Extensions
-In order to request a new Profile or an Extension either create an issue with the label `enhancement` or send an email to [tc-fhir](mailto:tcfhir@hl7.at)
-Use the issue to describe the intented use case and if applicable state some examples.
+In order to request a new Profile or an Extension either create an issue with the label `enhancement` or email [tc-fhir](mailto:tcfhir@hl7.at)
+Use the issue to describe the intended use case and if applicable state some examples.
 
 #### How Do I Submit a (Good) Enhancement
 
@@ -56,18 +56,18 @@ Use the issue to describe the intented use case and if applicable state some exa
 
 | Label name | Description |
 | --- | --- |
-| `discussion` | needs to be discussed in a meeting of the technical comitee fhir in HL7 Austria |
-| `review` | a solution to an open issue is provided, however the solution has to be reviewed acutally closing respective issue |
+| `discussion` | needs to be discussed in a meeting of the technical committee FHIR in HL7 Austria |
+| `review` | a solution to an open issue is provided, however the solution has to be reviewed before closing respective issue |
 | `bug` | marks a bug in the implementation |
 | `enhancement` | propose a new feature or a change in an existing profile/extension |
 | `blocked` | issues marked with `blocked` are dependent on other issue still in progress |
-| `hot` | marks issues with high priority, these are only assigned by the HL7 Austria tc-fhir, any invalid use on issues will be removed without discussion |
+| `hot` | marks issues with high priority, these are only assigned by the HL7 Austria TC-FHIR, any invalid use on issues will be removed without discussion |
 
 
-## Styleguides
+## Style guides
 
 ### Git Commit Messages
-A commit message must start with the correspoinding ticket number in GitHub (#TICKETNUMBER) each commit message must have a description which should be in present tense and use imperative voice
+A commit message must start with the corresponding ticket number in GitHub (#TICKETNUMBER) each commit message must have a description which should be in present tense and use imperative voice
 
 ### Naming Conventions
 
@@ -84,9 +84,11 @@ Most of these guidelines are suggestions, except the following rules that *must*
 A profile follows a prefix pattern, meaning that a name from left to right goes from specific to generic. It uses UpperCamelCase.
 
 **ProfileName** = [*Realm*-] *Use* , *ParentProfile*
-**Realm** = Is this profile supposed to be used in a realm? Then use the **countryCode**
+**Realm** = Is this profile supposed to be used in a realm? Then use the **countryCode**[^ISO3166-3]
 **Use** = What is this profile used for? **UpperCamelCase**
 **ParentProfile** =  Which profile does this profile extend from? **UpperCamelCase**
+
+[^ISO3166-3]: country codes are [ISO 3166-3](https://www.iso.org/iso-3166-country-codes.html) in the Alpha-2 code format, all lowercase.
 
 Example: Patient used in Austria, for ELGA.
 ```
@@ -110,7 +112,7 @@ An extension follows a suffix pattern, meaning that a name from left to right go
 
 **ExtensionName** = [*ProfileItIsFor*], {*FieldWithChildrenItIsIn*}, *FieldItAdds*
 **ProfileItIsFor** = Either Base Profile or **Profile** previously defined (optional if extension can occur anywhere -> Ex. NullFlavor), without the Realm.
-**FieldWithChildrenItIsIn** = Optional and Repeating, represents the **hierarchy** where the extension is to be used (optionaly if it can occur anywhere).
+**FieldWithChildrenItIsIn** = Optional and Repeating, represents the **hierarchy** where the extension is to be used (optionally if it can occur anywhere).
 **FieldItAdds** = **unique naming** for field
 
 Example: Extra patient field for "Sozialversicherungsnummer"
@@ -142,4 +144,4 @@ nullFlavor
 - TBD (add mail addresses and contact information)
 
 ## Support
-We actively monitor the issues coming in through the GitHub repository at https://github.com/HL7Austria/hl7-at-fhir-profiles/issues. You are welcome to register your bugs and feature suggestions there. For questions and broader discussions, we use the tc-austria channel on [Zulip](https://chat.fhir.org).
+We actively monitor the issues coming in through the GitHub repository at https://github.com/HL7Austria/hl7-at-fhir-profiles/issues. You are welcome to register your bugs and feature suggestions there. For questions and broader discussions, we use the TC-Austria channel on [Zulip](https://chat.fhir.org).


### PR DESCRIPTION
From the summary in #14 the naming conventions were added to CONTRIBUTING.md, including some examples for understanding. In the next call where we have time -> If vote succeeds merge into master.